### PR TITLE
[Feat] 요청 처리 시간 로깅

### DIFF
--- a/Backend/docker-compose-local.yml
+++ b/Backend/docker-compose-local.yml
@@ -1,0 +1,10 @@
+version: '3.0'
+
+services:
+  redis:
+    hostname: redis
+    container_name: redis
+    image: redis
+    command: redis-server --requirepass minia5085612 --port 6379
+    ports:
+      - 6379:6379

--- a/Backend/src/main/java/com/ssafy/mini/global/aspect/TimeTraceAspect.java
+++ b/Backend/src/main/java/com/ssafy/mini/global/aspect/TimeTraceAspect.java
@@ -1,0 +1,29 @@
+package com.ssafy.mini.global.aspect;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StopWatch;
+
+@Aspect
+@Component
+@Slf4j
+public class TimeTraceAspect {
+
+    @Around("execution(* com.ssafy.mini.domain.*.controller..*(..))")
+    public Object executionAspect(ProceedingJoinPoint joinPoint) throws Throwable
+    {
+        StopWatch stopWatch = new StopWatch();
+        stopWatch.start();
+
+        Object result = joinPoint.proceed();
+
+        stopWatch.stop();
+        log.info("{} ms 소요", stopWatch.getTotalTimeMillis());
+
+        return result;
+    }
+
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

#1 요청 처리 시간 로깅

## 📝작업 내용

- 로컬 환경에서 구동하기 위한 docker-compose 파일 정의
- cotroller단의 수행시간을 ms 단위로 측정